### PR TITLE
improve: replaced #dst operation with a variable to track array length.

### DIFF
--- a/lib/resty/http2/util.lua
+++ b/lib/resty/http2/util.lua
@@ -49,8 +49,9 @@ end
 
 
 function _M.pack_u16(u, dst)
-    dst[#dst + 1] = char(band(brshift(u, 8), 0xff))
-    dst[#dst + 1] = char(band(u, 0xff))
+    local len = #dst
+    dst[len + 1] = char(band(brshift(u, 8), 0xff))
+    dst[len + 2] = char(band(u, 0xff))
 end
 
 
@@ -60,10 +61,11 @@ end
 
 
 function _M.pack_u32(u, dst)
-    dst[#dst + 1] = char(band(brshift(u, 24), 0xff))
-    dst[#dst + 1] = char(band(brshift(u, 16), 0xff))
-    dst[#dst + 1] = char(band(brshift(u, 8), 0xff))
-    dst[#dst + 1] = char(band(u, 0xff))
+    local len = #dst
+    dst[len + 1] = char(band(brshift(u, 24), 0xff))
+    dst[len + 2] = char(band(brshift(u, 16), 0xff))
+    dst[len + 3] = char(band(brshift(u, 8), 0xff))
+    dst[len + 4] = char(band(u, 0xff))
 end
 
 


### PR DESCRIPTION
Eliminate #dst operation can save a 'lj_tab_len' function call, which is
not trivial in these simple utility functions. Not to mention that
'lj_tab_len' is often O(logn) in time complexity.